### PR TITLE
Makefile: Various makefile fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ endif
 all: LuaJIT/Makefile
 	cd ./LuaJIT && make -j
 	$(CC) main.c -O3 -c -o main.o -I ./LuaJIT/src
-	$(CC) main.o -lpthread -lm ${argp} -ldl ./LuaJIT/src/libluajit.a -o bench
+	$(CC) main.o -lpthread ${argp} ./LuaJIT/src/libluajit.a -lm -ldl -o bench
 
 LuaJIT/Makefile:
 	git submodule update --init --recursive

--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,19 @@ ifeq ($(shell uname), Darwin)
 	argp:=-largp -pagezero_size 10000 -image_base 100000000
 endif
 
-all:
-	git submodule update --init --recursive
+all: LuaJIT/Makefile
 	cd ./LuaJIT && make -j
 	$(CC) main.c -O3 -c -o main.o -I ./LuaJIT/src
 	$(CC) main.o -lpthread -lm ${argp} -ldl ./LuaJIT/src/libluajit.a -o bench
 
+LuaJIT/Makefile:
+	git submodule update --init --recursive
+
+clean:
+	cd ./LuaJIT && make clean
+	rm bench main.o
+
+distclean:
+	rm -rf LuaJIT
+	mkdir LuaJIT
+	rm bench main.o


### PR DESCRIPTION
Add new targets 'clean' and 'distclean' to remove build artifacts and
the entire LuaJIT source tree respectively.  Also run
git-submodule-update only when the source tree does not exist, which
could be either during the first checkout or immediately following a
distclean.  In all other cases, avoid touching the state of the LuaJIT
submodule source tree.