### PR TITLE
Benchmark driver fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,3 +24,7 @@ distclean:
 	rm -rf LuaJIT
 	mkdir LuaJIT
 	rm bench main.o
+
+run: bench
+	@echo "<benchmark>:<total runs>:<ops/s>"
+	@ls *.lua | while read f; do echo -n "$$f:"; ./bench $$f; done

--- a/Makefile
+++ b/Makefile
@@ -8,16 +8,23 @@ ifdef BENCH_DURATION
 	DURATION = -DBENCH_DURATION=$(BENCH_DURATION)
 endif
 
-all: LuaJIT/Makefile
-	cd ./LuaJIT && make -j
-	$(CC) main.c $(DURATION) -O3 -c -o main.o -I ./LuaJIT/src
-	$(CC) main.o -lpthread ${argp} ./LuaJIT/src/libluajit.a -lm -ldl -o bench
+ifndef LUAJIT_PATH
+	LUAJIT_PATH = ./LuaJIT
+endif
+
+LUAJIT_A = $(LUAJIT_PATH)/src/libluajit.a
+
+all: $(LUAJIT_PATH)/src/libluajit.a
+	$(CC) main.c $(DURATION) -O3 -c -o main.o -I $(LUAJIT_PATH)/src
+	$(CC) main.o -lpthread ${argp} $^ -lm -ldl -o bench
+
+$(LUAJIT_A): $(LUAJIT_PATH)/Makefile
+	make -C $(LUAJIT_PATH) -j
 
 LuaJIT/Makefile:
 	git submodule update --init --recursive
 
 clean:
-	cd ./LuaJIT && make clean
 	rm bench main.o
 
 distclean:

--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,13 @@ ifeq ($(shell uname), Darwin)
 	argp:=-largp -pagezero_size 10000 -image_base 100000000
 endif
 
+ifdef BENCH_DURATION
+	DURATION = -DBENCH_DURATION=$(BENCH_DURATION)
+endif
+
 all: LuaJIT/Makefile
 	cd ./LuaJIT && make -j
-	$(CC) main.c -O3 -c -o main.o -I ./LuaJIT/src
+	$(CC) main.c $(DURATION) -O3 -c -o main.o -I ./LuaJIT/src
 	$(CC) main.o -lpthread ${argp} ./LuaJIT/src/libluajit.a -lm -ldl -o bench
 
 LuaJIT/Makefile:

--- a/main.c
+++ b/main.c
@@ -23,6 +23,11 @@ typedef struct {
 	uint64_t  end_ns;
 } lua_task;
 
+/* Benchmark execution duration in seconds. */
+#ifndef BENCH_DURATION
+# define BENCH_DURATION 10
+#endif
+
 void *wrapper(void *arg) {
 	lua_task *task = (lua_task*)arg;
 	struct timespec start_time;
@@ -61,7 +66,7 @@ void *wrapper(void *arg) {
 
 
 		cur_time_ns = cur_time.tv_sec * 1e9 + cur_time.tv_nsec;
-		if (start_time_ns + 10 * 1e9 < cur_time_ns) {
+		if (start_time_ns + BENCH_DURATION * 1e9 < cur_time_ns) {
 			break;
 		}
 

--- a/main.c
+++ b/main.c
@@ -102,7 +102,7 @@ static char doc[] =
 static char args_doc[] = "file1";
 
 static struct argp_option options[] = {
-  {"concurency",  'c', "concurency", 0, "Number of threads" },
+  {"concurrency",  'c', "concurrency", 0, "Number of threads" },
   { 0 }
 };
 

--- a/main.c
+++ b/main.c
@@ -204,8 +204,7 @@ int main(int argc, char *argv[]) {
 
 	uint64_t duration = end_time_ns - start_time_ns;
 
-	fprintf(stderr, "Total times executed: %"PRId64"\n", total);
-	fprintf(stdout, "ops/s %.4f\n", (double)total * 1e9 / duration);
+	printf("%"PRId64":%.4f\n", total, (double) total * 1e9 / duration);
 
 	return 0;
 }


### PR DESCRIPTION
The current timing computation has an implicit assumption that the
benchmark ran for 10 seconds when in reality it will be a bit off, by
a few microseconds, if not milliseconds.  Fix this by recording the
start and end times at the entry and end points of each thread and
then use the earliest start and latest end times to get an estimate of
the total time the script iterations ran for.

Also increase the precision of the ops/s rate.